### PR TITLE
feat: Populate imported_payee and automatically process rules on sync

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -2,7 +2,6 @@
 import os, json, time, logging, datetime, decimal, requests, schedule
 from actual import Actual
 from actual.queries import get_or_create_account, reconcile_transaction, get_transactions, create_transaction
-from actual.
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 log = logging.getLogger(__name__)
@@ -235,7 +234,7 @@ def run_sync():
                             already_matched.append(t)
                             if t.changed():
                                 pending_map[key] = str(t.id)
-                                 += 1
+                                added += 1
                                 new_txn.append(t)
                                 log.info("Imported pending: %s | %s | %s", date, amount, payee)
                             else:
@@ -290,7 +289,12 @@ def run_sync():
 
                 except Exception as e:
                     log.warning("Skipping transaction: %s | %s", e, txn)
-            actual.run_rules(new_txn)
+
+            try:
+                actual.run_rules(new_txn)
+            except Exception as e:
+                log.error("Error applying Rules. Please check your actual budget rules: " + str(e))
+
             actual.commit()
             log.info("Done: %d added, %d confirmed, %d skipped", added, updated, skipped)
 


### PR DESCRIPTION
This PR fixes an issue where the raw bank text was missing from the imported_payee field, causing Actual Budget's rule to not apply when using "imported payee contains " rules.

Changes Made:

Fixed imported_payee mapping: Passed the payee variable to the imported_payee argument in both reconcile_transaction and create_transaction. Actual Budget now correctly stores the raw payee name from the bank, allowing rules to run correctly

Automated Rule Processing: Created a list (new_txn) to collect transactions where t.changed() is true. Passed this list to actual.run_rules() right before actual.commit(). This applies the user's Actual Budget rules.

Graceful Degradation for Rules: Wrapped actual.run_rules() in a try/except block. Because actualpy strictly validates rule fields via Pydantic (e.g., crashing on experimental payee_name actions), this prevents a single bad user rule from crashing the entire sync loop. If the rule engine fails, it logs the error and gracefully degrades to importing the transactions, allowing the user to manually apply them using the interface.