### PR TITLE
Add automatic timezone detection for sync scheduling

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,7 @@ SMTP_PORT            = "587"
 SMTP_FROM            = ""
 NOTIFY_ON            = "all"
 BRIDGE_BANK_URL      = ""
+TIMEZONE             = ""
 
 def _load():
     """Load config from file, then override with environment variables."""

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -3,6 +3,7 @@ import time
 import logging
 import threading
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from . import config, db, sync
 
 logger = logging.getLogger(__name__)
@@ -26,12 +27,39 @@ def _parse_time(time_str):
     parts = time_str.split(":")
     return int(parts[0]), int(parts[1])
 
+def _local_times_to_utc(sync_time_str, frequency, tz_name):
+    """Convert user's local sync times to UTC, accounting for DST."""
+    h, m = _parse_time(sync_time_str)
+    local_times = []
+    for i in range(0, 24, frequency):
+        local_times.append(f"{(h + i) % 24:02d}:{m:02d}")
+
+    if not tz_name:
+        return local_times
+
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception:
+        logger.warning("Invalid timezone %r, using times as-is", tz_name)
+        return local_times
+
+    today = datetime.now(tz).date()
+    utc_times = []
+    for lt in local_times:
+        lh, lm = _parse_time(lt)
+        local_dt = datetime(today.year, today.month, today.day, lh, lm, tzinfo=tz)
+        utc_dt = local_dt.astimezone(ZoneInfo("UTC"))
+        utc_times.append(f"{utc_dt.hour:02d}:{utc_dt.minute:02d}")
+
+    return utc_times
+
 _started = False
 
 def start():
     global _started
     sync_time = config.SYNC_TIME or "06:00"
     frequency = int(getattr(config, 'SYNC_FREQUENCY', '24') or '24')
+    tz_name = getattr(config, 'TIMEZONE', '') or ''
 
     # Clear any previously scheduled jobs (e.g. if settings changed)
     schedule.clear()
@@ -40,19 +68,21 @@ def start():
         logger.info("Scheduler disabled (manual only mode)")
         return
 
-    logger.info("Scheduler starting. Sync at %s, every %dh", sync_time, frequency)
+    logger.info("Scheduler starting. Sync at %s, every %dh, timezone %s",
+                sync_time, frequency, tz_name or "UTC")
 
-    if frequency == 24:
-        schedule.every().day.at(sync_time).do(_run_sync)
-    else:
-        h, m = _parse_time(sync_time)
-        times = []
-        for i in range(0, 24, frequency):
-            t_h = (h + i) % 24
-            times.append(f"{t_h:02d}:{m:02d}")
-        for t in times:
-            schedule.every().day.at(t).do(_run_sync)
-        logger.info("Sync times: %s", ", ".join(times))
+    utc_times = _local_times_to_utc(sync_time, frequency, tz_name)
+
+    if tz_name:
+        logger.info("Local times: %s -> UTC times: %s",
+                     ", ".join(_local_times_to_utc(sync_time, frequency, "")[:len(utc_times)]),
+                     ", ".join(utc_times))
+
+    for t in utc_times:
+        schedule.every().day.at(t).do(_run_sync)
+
+    if len(utc_times) > 1:
+        logger.info("Sync times: %s", ", ".join(utc_times))
 
     if _should_catchup(frequency):
         logger.info("Catch-up sync needed. Running now.")

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -379,6 +379,19 @@ def api_version():
 # API endpoints
 # ---------------------------------------------------------------------------
 
+@app.route("/api/timezone", methods=["POST"])
+def api_timezone():
+    from zoneinfo import available_timezones
+    data = request.get_json(silent=True) or {}
+    tz = data.get("tz", "")
+    if not tz or tz not in available_timezones():
+        return jsonify({"ok": False}), 400
+    if tz != config.TIMEZONE:
+        config.set("TIMEZONE", tz)
+        from .. import scheduler
+        scheduler.start()
+    return jsonify({"ok": True})
+
 @app.route("/api/bank-status")
 def bank_status():
     return jsonify({"connected": db.get_bank_account_count() > 0})
@@ -830,6 +843,7 @@ def status():
         sync_time=config.SYNC_TIME,
         sync_frequency=getattr(config, 'SYNC_FREQUENCY', '24') or '24',
         sync_times=_get_sync_times(),
+        timezone=config.TIMEZONE or "",
         notify_email=config.NOTIFY_EMAIL,
         activation_usage=act_info["usage"],
         activation_limit=act_info["limit"],

--- a/app/web/templates/base.html
+++ b/app/web/templates/base.html
@@ -58,5 +58,8 @@
       </div>
     </section>
   </main>
+<script>
+(function(){var tz=Intl.DateTimeFormat().resolvedOptions().timeZone;if(tz)fetch('/api/timezone',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({tz:tz})});})();
+</script>
 </body>
 </html>

--- a/app/web/templates/status.html
+++ b/app/web/templates/status.html
@@ -166,7 +166,7 @@
           </div>
           <button class="btn btn-ghost" type="submit" style="font-size:12px;">Save</button>
         </div>
-        <div style="font-size:12px;color:#94a3b8;margin-top:8px;" id="sync-times-preview">{% if sync_frequency != "0" %}Syncs at {{ sync_times }}{% endif %}</div>
+        <div style="font-size:12px;color:#94a3b8;margin-top:8px;" id="sync-times-preview">{% if sync_frequency != "0" %}Syncs at {{ sync_times }}{% if timezone %} ({{ timezone }}){% endif %}{% endif %}</div>
       </form>
       <script>
   function updateSyncPreview() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       - ./app/web/server.py:/app/web/server.py:ro
     ports:
       - "3002:3000"
-    environment:
-      - TZ=Europe/Lisbon
     extra_hosts:
       - "plex-server:host-gateway"
     networks:


### PR DESCRIPTION
## Summary
- Auto-detects customer timezone from browser via `Intl.DateTimeFormat`
- Converts sync times from local to UTC in scheduler using `zoneinfo`
- Handles DST transitions automatically (recalculates on each scheduler start)
- Existing customers get it on first page visit — no re-setup needed
- Reverts hardcoded TZ=Europe/Lisbon from docker-compose
- Fallback: no timezone stored = current UTC behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)