### PR TITLE
Enforce bank-seat limit globally via license server

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,5 +1,6 @@
 import sqlite3
 import os
+import uuid
 
 DB_PATH = "/data/instance.db"
 
@@ -36,6 +37,7 @@ def _ensure_tables(conn):
             actual_account TEXT NOT NULL,
             session_expiry TEXT,
             start_sync_date TEXT,
+            license_seat_id TEXT,
             created_at TEXT DEFAULT (datetime('now'))
         )
     """)
@@ -49,6 +51,7 @@ def _ensure_tables(conn):
         ("provider", "ALTER TABLE bank_accounts ADD COLUMN provider TEXT NOT NULL DEFAULT 'enablebanking'"),
         ("provider_credentials", "ALTER TABLE bank_accounts ADD COLUMN provider_credentials TEXT DEFAULT ''"),
         ("sync_mode", "ALTER TABLE bank_accounts ADD COLUMN sync_mode TEXT NOT NULL DEFAULT 'transactions'"),
+        ("license_seat_id", "ALTER TABLE bank_accounts ADD COLUMN license_seat_id TEXT"),
     ]:
         try:
             conn.execute(sql)
@@ -78,10 +81,23 @@ def _ensure_tables(conn):
                 actual_account = "Revolut"
             if uid:
                 conn.execute(
-                    "INSERT INTO bank_accounts (session_id, account_uid, bank_name, bank_country, actual_account, session_expiry) VALUES (?, ?, ?, ?, ?, ?)",
-                    (sid, uid, bank_name, bank_country, actual_account, exp)
+                    "INSERT INTO bank_accounts (session_id, account_uid, bank_name, bank_country, actual_account, session_expiry, license_seat_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (sid, uid, bank_name, bank_country, actual_account, exp, str(uuid.uuid4()))
                 )
                 conn.commit()
+
+def _ensure_bank_account_seat_ids(conn):
+    rows = conn.execute(
+        "SELECT id FROM bank_accounts WHERE license_seat_id IS NULL OR license_seat_id = ''"
+    ).fetchall()
+    if not rows:
+        return
+    for row in rows:
+        conn.execute(
+            "UPDATE bank_accounts SET license_seat_id = ? WHERE id = ?",
+            (str(uuid.uuid4()), row["id"])
+        )
+    conn.commit()
 
 def get_setting(key: str) -> str:
     with _conn() as conn:
@@ -150,6 +166,7 @@ def get_last_sync() -> str:
 def get_all_bank_accounts() -> list:
     with _conn() as conn:
         _ensure_tables(conn)
+        _ensure_bank_account_seat_ids(conn)
         rows = conn.execute(
             "SELECT * FROM bank_accounts ORDER BY created_at ASC"
         ).fetchall()
@@ -160,17 +177,28 @@ def get_bank_account_count() -> int:
         _ensure_tables(conn)
         return conn.execute("SELECT COUNT(*) FROM bank_accounts").fetchone()[0]
 
-def add_bank_account(session_id: str, account_uid: str, bank_name: str, bank_country: str, actual_account: str, session_expiry: str = "", start_sync_date: str = "", provider: str = "enablebanking", provider_credentials: str = "", sync_mode: str = "transactions"):
+def add_bank_account(session_id: str, account_uid: str, bank_name: str, bank_country: str, actual_account: str, session_expiry: str = "", start_sync_date: str = "", provider: str = "enablebanking", provider_credentials: str = "", sync_mode: str = "transactions", license_seat_id: str = ""):
     with _conn() as conn:
         _ensure_tables(conn)
-        conn.execute(
-            "INSERT INTO bank_accounts (session_id, account_uid, bank_name, bank_country, actual_account, session_expiry, start_sync_date, provider, provider_credentials, sync_mode) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (session_id, account_uid, bank_name, bank_country, actual_account, session_expiry, start_sync_date, provider, provider_credentials, sync_mode)
+        cur = conn.execute(
+            "INSERT INTO bank_accounts (session_id, account_uid, bank_name, bank_country, actual_account, session_expiry, start_sync_date, provider, provider_credentials, sync_mode, license_seat_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (session_id, account_uid, bank_name, bank_country, actual_account, session_expiry, start_sync_date, provider, provider_credentials, sync_mode, license_seat_id or str(uuid.uuid4()))
         )
         conn.commit()
+        return cur.lastrowid
+
+def get_bank_account(account_id: int):
+    with _conn() as conn:
+        _ensure_tables(conn)
+        _ensure_bank_account_seat_ids(conn)
+        row = conn.execute(
+            "SELECT * FROM bank_accounts WHERE id = ?",
+            (account_id,)
+        ).fetchone()
+        return dict(row) if row else None
 
 def update_bank_account_field(account_id: int, field: str, value: str):
-    allowed = {"start_sync_date", "session_id", "account_uid", "session_expiry", "actual_account", "bank_name", "bank_country", "provider", "provider_credentials", "sync_mode"}
+    allowed = {"start_sync_date", "session_id", "account_uid", "session_expiry", "actual_account", "bank_name", "bank_country", "provider", "provider_credentials", "sync_mode", "license_seat_id"}
     if field not in allowed:
         raise ValueError(f"Field {field} is not updatable")
     with _conn() as conn:

--- a/app/licence.py
+++ b/app/licence.py
@@ -80,15 +80,24 @@ def _get_fingerprint():
     db.set_setting("license_instance_id_v2", fp)
     return fp
 
+def get_machine_fingerprint():
+    return _get_fingerprint()
+
+def _post_json(path, payload, timeout=10):
+    resp = requests.post(LICENCE_BASE + path, json=payload, timeout=timeout)
+    try:
+        data = resp.json()
+    except ValueError:
+        data = {}
+    return resp, data
+
 def activate(key):
     fp = _get_fingerprint()
     try:
-        resp = requests.post(
-            LICENCE_BASE + "/activate",
-            json={"license_key": key, "machine_fingerprint": fp, "instance_name": "bridge-bank"},
-            timeout=10,
+        resp, data = _post_json(
+            "/activate",
+            {"license_key": key, "machine_fingerprint": fp, "instance_name": "bridge-bank"},
         )
-        data = resp.json()
         if resp.status_code in (200, 201) and data.get("valid"):
             db.set_setting("licence_key", key)
             return {"valid": True, "error": None}
@@ -112,12 +121,10 @@ def deactivate():
     if not key:
         return {"success": False, "error": "No active license to deactivate."}
     try:
-        resp = requests.post(
-            LICENCE_BASE + "/deactivate",
-            json={"license_key": key, "machine_fingerprint": fp},
-            timeout=10,
+        resp, data = _post_json(
+            "/deactivate",
+            {"license_key": key, "machine_fingerprint": fp},
         )
-        data = resp.json()
         if resp.status_code == 200:
             db.set_setting("licence_key", "")
             db.set_setting("license_instance_id", "")
@@ -138,12 +145,10 @@ def validate(key=None):
         return {"valid": False, "error": "No license key configured."}
     fp = _get_fingerprint()
     try:
-        resp = requests.post(
-            LICENCE_BASE + "/validate",
-            json={"license_key": key, "machine_fingerprint": fp},
-            timeout=10,
+        resp, data = _post_json(
+            "/validate",
+            {"license_key": key, "machine_fingerprint": fp},
         )
-        data = resp.json()
         if resp.status_code == 200 and data.get("valid"):
             db.set_setting("licence_validated", "1")
             return {"valid": True, "error": None}
@@ -167,16 +172,15 @@ def get_activation_info():
     key = config.LICENCE_KEY
     defaults = {"usage": 0, "limit": 2, "bank_account_limit": 2, "is_trial": False, "expires_at": None}
     if not key:
-        return defaults
+        return {**defaults, "bank_seat_usage": 0}
     try:
-        resp = requests.post("https://api.bridgebank.app/info",
-            json={"license_key": key}, timeout=5)
+        resp, d = _post_json("/info", {"license_key": key}, timeout=5)
         if resp.status_code == 200:
-            d = resp.json()
             info = {
                 "usage": d.get("activation_usage", 0),
                 "limit": d.get("activation_limit", 2),
                 "bank_account_limit": d.get("bank_account_limit", 2),
+                "bank_seat_usage": d.get("bank_seat_usage", 0),
                 "is_trial": d.get("is_trial", False),
                 "expires_at": d.get("expires_at"),
             }
@@ -187,4 +191,85 @@ def get_activation_info():
     cached = _get_cached_license_info()
     if cached:
         return cached
-    return defaults
+    return {**defaults, "bank_seat_usage": 0}
+
+def claim_bank_seat(account, key=None):
+    from . import config
+    key = key or config.LICENCE_KEY
+    if not key:
+        return {"ok": False, "error": "No license key configured."}
+    seat_id = (account.get("license_seat_id") or "").strip()
+    if not seat_id:
+        return {"ok": False, "error": "Missing local bank seat ID."}
+    fp = _get_fingerprint()
+    payload = {
+        "license_key": key,
+        "machine_fingerprint": fp,
+        "seat_id": seat_id,
+        "bank_name": account.get("bank_name", ""),
+        "actual_account": account.get("actual_account", ""),
+        "sync_mode": account.get("sync_mode", "transactions"),
+    }
+    try:
+        resp, data = _post_json("/bank-seats/claim", payload)
+        if resp.status_code == 200:
+            return {
+                "ok": True,
+                "used": data.get("used"),
+                "limit": data.get("limit"),
+            }
+        return {
+            "ok": False,
+            "error": data.get("error") or "Could not reserve a bank slot for this licence.",
+            "used": data.get("used"),
+            "limit": data.get("limit"),
+        }
+    except requests.RequestException as e:
+        logger.warning("Bank seat claim failed (network): %s", e)
+        return {
+            "ok": False,
+            "error": "Could not reach the license server to confirm bank slot availability.",
+            "network": True,
+        }
+
+def sync_bank_seats(accounts, key=None):
+    from . import config
+    key = key or config.LICENCE_KEY
+    if not key:
+        return {"ok": False, "error": "No license key configured."}
+    fp = _get_fingerprint()
+    payload = {
+        "license_key": key,
+        "machine_fingerprint": fp,
+        "seats": [
+            {
+                "seat_id": account.get("license_seat_id", ""),
+                "bank_name": account.get("bank_name", ""),
+                "actual_account": account.get("actual_account", ""),
+                "sync_mode": account.get("sync_mode", "transactions"),
+            }
+            for account in accounts
+            if account.get("license_seat_id")
+        ],
+    }
+    try:
+        resp, data = _post_json("/bank-seats/sync", payload)
+        if resp.status_code == 200:
+            return {
+                "ok": True,
+                "used": data.get("used"),
+                "limit": data.get("limit"),
+            }
+        return {
+            "ok": False,
+            "error": data.get("error") or "Could not verify bank slots for this licence.",
+            "used": data.get("used"),
+            "limit": data.get("limit"),
+        }
+    except requests.RequestException as e:
+        logger.warning("Bank seat sync failed (network): %s", e)
+        return {
+            "ok": False,
+            "error": "Could not reach the license server to verify connected bank slots.",
+            "network": True,
+        }

--- a/app/sync.py
+++ b/app/sync.py
@@ -450,6 +450,20 @@ def run():
         db.log_sync("failure", message=msg)
         return False, 0, msg
 
+    seat_result = licence.sync_bank_seats(all_accounts)
+    if not seat_result.get("ok"):
+        if seat_result.get("network"):
+            log.warning("Bank seat verification skipped: %s", seat_result.get("error"))
+        else:
+            msg = seat_result.get("error") or "Bank account limit reached for this licence."
+            log.error(msg)
+            db.set_setting("license_bank_limit_error", msg)
+            db.log_sync("failure", message=msg)
+            email_notify.send_failure(msg)
+            return False, 0, msg
+    else:
+        db.set_setting("license_bank_limit_error", "")
+
     state = _load_state()
     total_added = 0
     errors = []

--- a/app/web/server.py
+++ b/app/web/server.py
@@ -52,6 +52,45 @@ def _get_bank_account_limit() -> int:
     except Exception:
         return 2
 
+def _sync_bank_seats(accounts):
+    if not config.LICENCE_KEY:
+        db.set_setting("license_bank_limit_error", "")
+        return {"ok": True, "used": 0, "limit": _get_bank_account_limit()}
+    result = licence.sync_bank_seats(accounts)
+    if result.get("ok"):
+        db.set_setting("license_bank_limit_error", "")
+    elif not result.get("network"):
+        db.set_setting("license_bank_limit_error", result.get("error", ""))
+    return result
+
+def _get_bank_seat_error(accounts=None):
+    accounts = accounts if accounts is not None else db.get_all_bank_accounts()
+    result = _sync_bank_seats(accounts)
+    if result.get("ok") or result.get("network"):
+        return None, result
+    return result.get("error"), result
+
+def _ensure_global_bank_capacity(current_accounts, new_seats=1):
+    result = _sync_bank_seats(current_accounts)
+    if not result.get("ok"):
+        if result.get("network"):
+            return "Could not confirm your global bank slot availability right now. Please try again in a moment."
+        return result.get("error") or "Bank account limit reached for this licence."
+    used = int(result.get("used") or 0)
+    limit = int(result.get("limit") or _get_bank_account_limit())
+    if used + new_seats > limit:
+        return f"Bank account limit reached ({limit}). Disconnect a bank on another machine or add another bank slot before connecting a new one."
+    return None
+
+def _claim_bank_seat(account):
+    result = licence.claim_bank_seat(account)
+    if result.get("ok"):
+        db.set_setting("license_bank_limit_error", "")
+        return None
+    if result.get("network"):
+        return "Could not confirm your global bank slot availability right now. Please try again in a moment."
+    return result.get("error") or "Bank account limit reached for this licence."
+
 COUNTRIES = [
     ("AT","Austria"),("BE","Belgium"),("HR","Croatia"),("CY","Cyprus"),
     ("CZ","Czech Republic"),("DK","Denmark"),("EE","Estonia"),("FI","Finland"),
@@ -466,9 +505,10 @@ def bank():
                 error = "Please select a bank."
             elif not actual_account:
                 error = "Please enter the Actual Budget account name."
-            elif db.get_bank_account_count() >= _get_bank_account_limit():
-                error = "Bank account limit reached. Disconnect a bank or add another slot before connecting a new one."
             else:
+                current_accounts = db.get_all_bank_accounts()
+                error = _ensure_global_bank_capacity(current_accounts, new_seats=1)
+            if not error:
                 # Validate that the account exists in Actual Budget
                 try:
                     from actual import Actual
@@ -510,9 +550,10 @@ def bank():
                 error = "Please select a provider."
             elif not actual_account:
                 error = "Please enter the Actual Budget account name."
-            elif db.get_bank_account_count() >= _get_bank_account_limit():
-                error = "Bank account limit reached. Disconnect an account or add another slot before connecting a new one."
             else:
+                current_accounts = db.get_all_bank_accounts()
+                error = _ensure_global_bank_capacity(current_accounts, new_seats=1)
+            if not error:
                 # Collect credentials from form
                 from ..providers import get_provider, PROVIDERS
                 if provider_name not in PROVIDERS:
@@ -555,7 +596,7 @@ def bank():
                 if not error:
                     from .. import crypto
                     encrypted = crypto.encrypt_credentials(credentials)
-                    db.add_bank_account(
+                    account_id = db.add_bank_account(
                         session_id="",
                         account_uid="",
                         bank_name=provider.display_name,
@@ -565,9 +606,15 @@ def bank():
                         provider_credentials=encrypted,
                         sync_mode="balance",
                     )
-                    _start_scheduler_if_ready()
-                    threading.Thread(target=sync.run, daemon=True).start()
-                    return redirect(url_for("bank", success=1))
+                    account = db.get_bank_account(account_id)
+                    seat_error = _claim_bank_seat(account)
+                    if seat_error:
+                        db.remove_bank_account(account_id)
+                        error = seat_error
+                    else:
+                        _start_scheduler_if_ready()
+                        threading.Thread(target=sync.run, daemon=True).start()
+                        return redirect(url_for("bank", success=1))
 
         elif action == "cancel":
             db.set_setting("pending_session_id", "")
@@ -578,12 +625,14 @@ def bank():
             return redirect(url_for("bank"))
 
     all_accounts = db.get_all_bank_accounts()
+    bank_seat_error, bank_seat_result = _get_bank_seat_error(all_accounts)
     days_left    = _get_days_left()
     success      = request.args.get("success")
     pem_ready    = bool(db.get_setting("eb_pem_content") or __import__('os').path.exists("/data/private.pem"))
 
     # Fetch bank account limit from licence API
-    bank_account_limit = _get_bank_account_limit()
+    bank_account_limit = int((bank_seat_result or {}).get("limit") or _get_bank_account_limit())
+    bank_seat_usage = int((bank_seat_result or {}).get("used") or len(all_accounts))
 
     from ..providers import get_all_providers
     balance_providers = get_all_providers()
@@ -591,12 +640,14 @@ def bank():
     return render_template("bank.html",
         error=error,
         success=success,
+        bank_seat_error=bank_seat_error,
         auth_url=auth_url,
         all_accounts=all_accounts,
         days_left=days_left,
         pem_ready=pem_ready,
         eb_app_id=config.EB_APPLICATION_ID or db.get_setting("eb_app_id"),
         bank_account_limit=bank_account_limit,
+        bank_seat_usage=bank_seat_usage,
         bank_slot_url=f"https://buy.stripe.com/00waEQ6subzF0PZ9EBcMM05?client_reference_id={config.LICENCE_KEY}",
         today=__import__('datetime').date.today().isoformat(),
         active="bank",
@@ -626,7 +677,9 @@ def reauthorise():
         return redirect(url_for("bank") + f"?error=Could not start re-authorisation: {e}")
 
     all_accounts = db.get_all_bank_accounts()
-    bank_account_limit = _get_bank_account_limit()
+    bank_seat_error, bank_seat_result = _get_bank_seat_error(all_accounts)
+    bank_account_limit = int((bank_seat_result or {}).get("limit") or _get_bank_account_limit())
+    bank_seat_usage = int((bank_seat_result or {}).get("used") or len(all_accounts))
 
     from ..providers import get_all_providers
     balance_providers = get_all_providers()
@@ -635,10 +688,12 @@ def reauthorise():
         error=None,
         success=None,
         auth_url=auth_url,
+        bank_seat_error=bank_seat_error,
         all_accounts=all_accounts,
         pem_ready=True,
         eb_app_id=config.EB_APPLICATION_ID or db.get_setting("eb_app_id"),
         bank_account_limit=bank_account_limit,
+        bank_seat_usage=bank_seat_usage,
         bank_slot_url=f"https://buy.stripe.com/00waEQ6subzF0PZ9EBcMM05?client_reference_id={config.LICENCE_KEY}",
         today=__import__('datetime').date.today().isoformat(),
         active="bank",
@@ -655,6 +710,7 @@ def _save_bank_account(session_id, account_uid, valid_until):
     bank_name       = db.get_setting("pending_bank_name") or config.EB_BANK_NAME
     bank_country    = db.get_setting("pending_bank_country") or config.EB_BANK_COUNTRY
     start_sync_date = db.get_setting("pending_start_sync_date") or ""
+    account_id = None
     if reauth_account_id:
         account_id = int(reauth_account_id)
         db.update_bank_account_field(account_id, "session_id", session_id)
@@ -663,9 +719,10 @@ def _save_bank_account(session_id, account_uid, valid_until):
         db.update_bank_account_field(account_id, "bank_name", bank_name)
         db.update_bank_account_field(account_id, "bank_country", bank_country)
     else:
-        if db.get_bank_account_count() >= _get_bank_account_limit():
-            raise ValueError("Bank account limit reached. Disconnect a bank or add another slot before connecting a new one.")
-        db.add_bank_account(
+        capacity_error = _ensure_global_bank_capacity(db.get_all_bank_accounts(), new_seats=1)
+        if capacity_error:
+            raise ValueError(capacity_error)
+        account_id = db.add_bank_account(
             session_id=session_id,
             account_uid=account_uid,
             bank_name=bank_name,
@@ -674,6 +731,12 @@ def _save_bank_account(session_id, account_uid, valid_until):
             session_expiry=valid_until,
             start_sync_date=start_sync_date,
         )
+    account = db.get_bank_account(account_id)
+    seat_error = _claim_bank_seat(account)
+    if seat_error:
+        if not reauth_account_id and account_id:
+            db.remove_bank_account(account_id)
+        raise ValueError(seat_error)
     # Clear pending settings
     for key in ["pending_actual_account", "pending_bank_name", "pending_bank_country",
                 "pending_start_sync_date", "pending_session_state", "pending_session_valid_until",
@@ -769,6 +832,7 @@ def status():
     log_data     = db.get_sync_log_page(page=page, per_page=5)
     syncs        = log_data["syncs"]
     all_accounts = db.get_all_bank_accounts()
+    bank_seat_error, bank_seat_result = _get_bank_seat_error(all_accounts)
     days_left    = _get_days_left()
     last_sync    = db.get_last_sync()
     act_info     = licence.get_activation_info()
@@ -851,6 +915,9 @@ def status():
         trial_expires_at=act_info.get("expires_at", "")[:10] if act_info.get("expires_at") else None,
         license_sync_failed=license_sync_failed,
         license_limit_reached=(license_sync_failed and act_info["usage"] >= act_info["limit"] and act_info["limit"] > 0),
+        bank_seat_error=bank_seat_error,
+        bank_seat_usage=(bank_seat_result or {}).get("used", act_info.get("bank_seat_usage", 0)),
+        bank_account_limit=(bank_seat_result or {}).get("limit", act_info.get("bank_account_limit", 2)),
         page=log_data["page"],
         total_pages=log_data["total_pages"],
         active="status",
@@ -953,7 +1020,11 @@ def reset_pem():
 def disconnect():
     account_id = request.form.get("account_id")
     if account_id:
+        account = db.get_bank_account(int(account_id))
         db.remove_bank_account(int(account_id))
+        result = _sync_bank_seats(db.get_all_bank_accounts())
+        if not result.get("ok") and not result.get("network") and account:
+            logger.warning("Failed to release bank seat for %s: %s", account.get("bank_name"), result.get("error"))
     return redirect(url_for("bank"))
 
 @app.route("/reset-sync", methods=["POST"])

--- a/app/web/templates/bank.html
+++ b/app/web/templates/bank.html
@@ -14,6 +14,9 @@
 {% if error %}
   <div class="alert alert-error">{{ error }}</div>
 {% endif %}
+{% if bank_seat_error %}
+  <div class="alert alert-error">{{ bank_seat_error }}</div>
+{% endif %}
 {% if success %}
   <div class="alert alert-success">Bank connected. Your first sync will run shortly.</div>
 {% endif %}
@@ -54,7 +57,7 @@
     </div>
 
     {% if all_accounts %}
-    <div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.8px;color:#94a3b8;margin-bottom:0.5rem;">Connected accounts ({{ all_accounts|length }}/{{ bank_account_limit }})</div>
+    <div style="font-size:11px;font-weight:600;text-transform:uppercase;letter-spacing:0.8px;color:#94a3b8;margin-bottom:0.5rem;">Connected accounts ({{ bank_seat_usage }}/{{ bank_account_limit }} across all machines)</div>
     <div style="font-size:11px;color:#4a5568;margin-bottom:0.75rem;">Reset sync re-imports transactions from the start date. Existing transactions won't be duplicated.</div>
     {% for a in all_accounts %}
     <div style="margin-bottom:0.75rem;padding:12px 14px;border:1px solid #253450;border-radius:8px;">
@@ -103,9 +106,9 @@
     <hr style="border:none;border-top:1px solid #253450;margin:1.25rem 0;">
     {% endif %}
 
-    {% if all_accounts|length >= bank_account_limit %}
+    {% if bank_seat_usage >= bank_account_limit %}
     <div style="padding:14px;background:#080b12;border:1px solid #253450;border-radius:8px;font-size:13px;color:#94a3b8;text-align:center;">
-      Account limit reached. <a href="{{ bank_slot_url }}" target="_blank" style="color:#e8edf5;font-weight:600;">Add 1 more &rarr;</a>
+      Account limit reached ({{ bank_seat_usage }}/{{ bank_account_limit }} across all machines). <a href="{{ bank_slot_url }}" target="_blank" style="color:#e8edf5;font-weight:600;">Add 1 more &rarr;</a>
     </div>
     {% else %}
     {% if balance_providers %}

--- a/app/web/templates/status.html
+++ b/app/web/templates/status.html
@@ -23,6 +23,10 @@
   {% endif %}
 {% endif %}
 
+{% if bank_seat_error %}
+  <div class="alert alert-error">{{ bank_seat_error }} <a href="/bank" style="color:inherit;font-weight:600;">Manage banks &rarr;</a></div>
+{% endif %}
+
 {% if days_left is not none and days_left <= 14 %}
   <div class="alert alert-warn">A bank connection expires in {{ days_left }} day{{ 's' if days_left != 1 else '' }}. <a href="/bank" style="color:inherit;font-weight:600;">Manage banks &rarr;</a></div>
 {% endif %}
@@ -97,6 +101,7 @@
         <span class="stat-value utc-time">{{ last_sync or 'Never' }}</span>
       </div>
       <div class="stat-row"><span class="stat-label">Notifications</span><span class="stat-value">{{ notify_email or 'Disabled' }}</span></div>
+      <div class="stat-row"><span class="stat-label">Bank slots</span><span class="stat-value">{{ bank_seat_usage }}/{{ bank_account_limit }}</span></div>
       {% if total_tx >= 0 %}
       <div class="stat-row"><span class="stat-label">Transactions synced</span><span class="stat-value">{{ total_tx }}</span></div>
       {% endif %}


### PR DESCRIPTION
## Summary
Each bank_account gets a stable `license_seat_id` (UUID) that's claimed with the license server on connect and reconciled on every sync. Bank limit is enforced globally across machines.

- Connect/reconnect paths call `/bank-seats/claim` and roll back the local row on 409.
- `sync.run()` calls `/bank-seats/sync` first; hard-fails the run if the server reports over-limit (network errors are logged and skipped).
- `/disconnect` re-syncs to release the freed seat.
- `bank.html` shows global used/limit ("2/3 across all machines") instead of the local row count.
- Removed the client-side `sync([])` shim before deactivate — the server now cleans `bank_seats` on `/deactivate` atomically.

Requires license-api#1 to be merged and deployed first.

## Test plan
- [x] Python syntax check (`py_compile` on db.py, licence.py, sync.py, server.py).
- [x] Server-side flow tested via license-api smoke test (14/14).
- [ ] One live connect-disconnect on a real install after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)