### PR TITLE
Clean up public docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       - "3002:3000"
     extra_hosts:
       - "plex-server:host-gateway"
-    networks:
-      - media
 
   watchtower:
     image: nickfedor/watchtower
@@ -28,7 +26,3 @@ services:
     environment:
       - WATCHTOWER_LOG_LEVEL=warn
       - WATCHTOWER_HTTP_API_TOKEN=bridge-bank-update
-
-networks:
-  media:
-    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ./data:/data
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/compose:ro
-      - ./app/web/server.py:/app/web/server.py:ro
     ports:
       - "3002:3000"
     extra_hosts:


### PR DESCRIPTION
## Summary
Two cleanups to the public `docker-compose.yml` so customers downloading it via the README's `curl -O` get a file that just works.

**1. Remove the external `media` network**
- Customers running `curl -O` + `docker compose up -d` were hitting `network media declared as external, but could not be found` because that network only exists on my home server.
- Side effect: bridge-bank and bridge-bank-watchtower now share the auto-created default compose network, so the in-app **Check for updates** button (`server.py` → `http://bridge-bank-watchtower:8080`) actually resolves the watchtower hostname reliably for the first time.

**2. Remove the dead `./app/web/server.py:/app/web/server.py:ro` bind mount**
- The mount target inside the container (`/app/web/server.py`) doesn't exist in the image. Dockerfile is `WORKDIR /app` + `COPY . .`, so the real server.py lives at `/app/app/web/server.py`, and `main.py` imports `app.web.server` which resolves to that path. The bind mount was never read by anything.
- Origin: commit 9e0e452 retargeted the mount from `/app/app/web/server.py` (correct) to `/app/web/server.py` (wrong), silently killing the hot-reload purpose.
- Effect on customers without `./app/web/server.py` on their host: Docker creates a phantom empty `app/web/server.py/` directory tree in their install folder. Annoying clutter, no functional impact.

## What stays
- `extra_hosts: plex-server:host-gateway` — needed locally for `ACTUAL_URL=http://plex-server:5006`, harmless to customers (they never use that hostname).
- `.:/compose:ro` — actually used by `server.py:34` to detect the container name and by the in-app updater to find the compose file path.

## Why this is safe for the home-server deploy
- bridge-bank-api still reaches bridge-bank via host gateway IP + published port (`http://172.18.0.1:3002`), unaffected.
- Watchtower talks to bridge-bank via the Docker socket, not the network.
- ACTUAL_URL resolution still works via `extra_hosts`.
- I deploy via image rebuild + Watchtower, not via the deleted hot-reload mount.

## Test plan
- [ ] Merge → auto-deploy syncs new compose to home server
- [ ] After redeploy: confirm bridge-bank → Actual Budget sync still works (logs in Status page)
- [ ] After redeploy: confirm in-app **Check for updates** button works
- [ ] Confirm bridge-bank-api `/banks` endpoint still returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)