### PR TITLE
Stop sending bank metadata in seat claim/sync payloads

### DIFF
--- a/app/licence.py
+++ b/app/licence.py
@@ -206,9 +206,6 @@ def claim_bank_seat(account, key=None):
         "license_key": key,
         "machine_fingerprint": fp,
         "seat_id": seat_id,
-        "bank_name": account.get("bank_name", ""),
-        "actual_account": account.get("actual_account", ""),
-        "sync_mode": account.get("sync_mode", "transactions"),
     }
     try:
         resp, data = _post_json("/bank-seats/claim", payload)
@@ -242,12 +239,7 @@ def sync_bank_seats(accounts, key=None):
         "license_key": key,
         "machine_fingerprint": fp,
         "seats": [
-            {
-                "seat_id": account.get("license_seat_id", ""),
-                "bank_name": account.get("bank_name", ""),
-                "actual_account": account.get("actual_account", ""),
-                "sync_mode": account.get("sync_mode", "transactions"),
-            }
+            {"seat_id": account.get("license_seat_id", "")}
             for account in accounts
             if account.get("license_seat_id")
         ],


### PR DESCRIPTION
## Summary
- Strip \`bank_name\`, \`actual_account\`, \`sync_mode\` from the \`/bank-seats/claim\` and \`/bank-seats/sync\` request bodies.
- Seat enforcement only needs \`seat_id\`; the three fields were sent but no longer stored server-side.

## Coordinated change
Pairs with [license-api#4](https://github.com/DAdjadj/license-api/pull/4) (server stops storing).

## Test plan
- [ ] Existing instances continue to claim/sync seats successfully against new server.
- [ ] New seats appear in admin without bank metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)